### PR TITLE
tiny_skia: apply `clip_mask` to shadows

### DIFF
--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -148,7 +148,7 @@ impl Engine {
                     pixmap.as_ref(),
                     &tiny_skia::PixmapPaint::default(),
                     tiny_skia::Transform::default(),
-                    None,
+                    clip_mask,
                 );
             }
         }


### PR DESCRIPTION
I found that the shadow rendering code isn't using the clip bounds properly. leading to some artifacting.

Here's demo (I've modified the styling to show the shadows).

Without `clip_mask`
![Screenshot_20250102_124705](https://github.com/user-attachments/assets/3dfb55f9-544f-4a92-8155-7acbf9f87a7e)
![Screenshot_20250102_124734](https://github.com/user-attachments/assets/4b85194f-03b6-4c74-8482-237a0849745f)

With `clip_mask`
![Screenshot_20250102_124807](https://github.com/user-attachments/assets/3c3aad64-fe5f-4d13-b09c-d8d3129b782a)
![Screenshot_20250102_124814](https://github.com/user-attachments/assets/4caaff65-6097-4aac-80b5-7e79184551c8)

Note that the text is still overwriting the shadows (for both cases). But I think this should get us closer :)