### PR TITLE
tiny_skia: fix incorrect shadow clipping

### DIFF
--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -44,15 +44,16 @@ impl Engine {
             quad.bounds.height.is_normal(),
             "Quad with non-normal height!"
         );
+        let physical_bounds_with_shadow = quad.bounds_with_shadow() * transformation;
 
-        let physical_bounds = quad.bounds * transformation;
-
-        if !clip_bounds.intersects(&physical_bounds) {
+        if !clip_bounds.intersects(&physical_bounds_with_shadow) {
             return;
         }
 
-        let clip_mask = (!physical_bounds.is_within(&clip_bounds))
+        let clip_mask = (!physical_bounds_with_shadow.is_within(&clip_bounds))
             .then_some(clip_mask as &_);
+
+        let physical_bounds = quad.bounds * transformation;
 
         let transform = into_transform(transformation);
 


### PR DESCRIPTION
This should address the issue where shadows aren't being properly clipped.

We're now considering the quad's shadow bounds when testing to see if it should apply the clipping mask.

before:
![Screenshot_20250107_151643](https://github.com/user-attachments/assets/50fdb08c-73a4-4d7e-939c-b1f98e1c87a9)

after:
![Screenshot_20250107_151558](https://github.com/user-attachments/assets/95f9929c-9d97-400b-91bd-1c5871c0e589)

Coincidentally, this also fixes the issue where text would overwrite the shadows:

before:
![Screenshot_20250107_151950](https://github.com/user-attachments/assets/a2d1308a-c12d-4efa-853f-f843d13dd389)

after:
![Screenshot_20250107_151919](https://github.com/user-attachments/assets/54a35aef-4751-45e6-8d57-ac0270efb029)
